### PR TITLE
Blog: Add-api-endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,11 +49,11 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'cancancan'
   gem 'debug', platforms: %i[mri windows]
+  gem 'devise-jwt'
   gem 'factory_bot_rails'
   gem 'rails-controller-testing'
   gem 'rspec-rails'
   gem 'will_paginate'
-  gem 'devise-jwt'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'rspec-rails'
   gem 'will_paginate'
+  gem 'devise-jwt'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,9 +108,21 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-jwt (0.11.0)
+      devise (~> 4.0)
+      warden-jwt_auth (~> 0.8)
     diff-lcs (1.5.0)
     drb (2.2.0)
       ruby2_keywords
+    dry-auto_inject (1.0.1)
+      dry-core (~> 1.0)
+      zeitwerk (~> 2.6)
+    dry-configurable (1.1.0)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
+    dry-core (1.0.1)
+      concurrent-ruby (~> 1.0)
+      zeitwerk (~> 2.6)
     erubi (1.12.0)
     factory_bot (6.4.5)
       activesupport (>= 5.0.0)
@@ -133,6 +145,7 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.7.1)
+    jwt (2.7.1)
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
@@ -291,6 +304,11 @@ GEM
     unicode-display_width (2.5.0)
     warden (1.2.9)
       rack (>= 2.0.9)
+    warden-jwt_auth (0.8.0)
+      dry-auto_inject (>= 0.8, < 2)
+      dry-configurable (>= 0.13, < 2)
+      jwt (~> 2.1)
+      warden (~> 1.2)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -320,6 +338,7 @@ DEPENDENCIES
   capybara
   debug
   devise (~> 4.9)
+  devise-jwt
   factory_bot_rails
   importmap-rails
   jbuilder

--- a/README.md
+++ b/README.md
@@ -120,10 +120,22 @@ To run the project tests, execute the following command:
 
 ## 👥 Authors <a name="authors"></a>
 
-👤 **Author1**
+👤 **George Hamman**
 
 - GitHub: [@githubhandle](https://github.com/George7h)
 - LinkedIn: <a href="https://www.linkedin.com/in/george-hamman-95b98224b/">George Hamman</a>
+  
+👤 **malikhaiderkhan**
+
+- GitHub: [@malikhaiderkhan](https://github.com/malikhaiderkhan)
+- Twitter: [@malikhaiderkha](https://twitter.com/malikhaiderkha)
+- LinkedIn: [@malikhaiderkhan](https://www.linkedin.com/in/malik-haider-khan-b53188140)
+
+👤 **Fombi Magnus-Favour**
+
+- GitHub: [Fombi-Favour](https://github.com/Fombi-Favour)
+- Twitter: [@FavourFombi](https://twitter.com/FavourFombi)
+- LinkedIn: [Fombi Favour](https://www.linkedin.com/in/fombi-favour/)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,0 +1,2 @@
+class Api::CommentsController < ApplicationController
+end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,2 +1,34 @@
-class Api::CommentsController < ApplicationController
-end
+module Api
+    class CommentsController < ApplicationController
+      skip_before_action :authenticate_user!, only: %i[index create]
+      skip_before_action :verify_authenticity_token
+      before_action :set_user_post
+  
+      def index
+        @comments = @post.comments
+        render json: @comments
+      end
+  
+      def create
+        @comment = @post.comments.new(comment_params)
+        @comment.user = @user
+  
+        if @comment.save
+          render json: @comment, status: :created
+        else
+          render json: { error: 'Comment not created' }, status: :unprocessable_entity
+        end
+      end
+  
+      private
+  
+      def set_user_post
+        @user = User.find(params[:user_id])
+        @post = @user.posts.find(params[:post_id])
+      end
+  
+      def comment_params
+        params.require(:comment).permit(:text)
+      end
+    end
+  end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -5,11 +5,15 @@ module Api
     before_action :set_user_post
 
     def index
+      @user = User.find(params[:user_id])
+      @post = @user.posts.find(params[:post_id])
       @comments = @post.comments
       render json: @comments
     end
 
     def create
+      @user = User.find(params[:user_id])
+      @post = @user.posts.find(params[:post_id])
       @comment = @post.comments.new(comment_params)
       @comment.user = @user
 

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,34 +1,34 @@
 module Api
-    class CommentsController < ApplicationController
-      skip_before_action :authenticate_user!, only: %i[index create]
-      skip_before_action :verify_authenticity_token
-      before_action :set_user_post
-  
-      def index
-        @comments = @post.comments
-        render json: @comments
-      end
-  
-      def create
-        @comment = @post.comments.new(comment_params)
-        @comment.user = @user
-  
-        if @comment.save
-          render json: @comment, status: :created
-        else
-          render json: { error: 'Comment not created' }, status: :unprocessable_entity
-        end
-      end
-  
-      private
-  
-      def set_user_post
-        @user = User.find(params[:user_id])
-        @post = @user.posts.find(params[:post_id])
-      end
-  
-      def comment_params
-        params.require(:comment).permit(:text)
+  class CommentsController < ApplicationController
+    skip_before_action :authenticate_user!, only: %i[index create]
+    skip_before_action :verify_authenticity_token
+    before_action :set_user_post
+
+    def index
+      @comments = @post.comments
+      render json: @comments
+    end
+
+    def create
+      @comment = @post.comments.new(comment_params)
+      @comment.user = @user
+
+      if @comment.save
+        render json: @comment, status: :created
+      else
+        render json: { error: 'Comment not created' }, status: :unprocessable_entity
       end
     end
+
+    private
+
+    def set_user_post
+      @user = User.find(params[:user_id])
+      @post = @user.posts.find(params[:post_id])
+    end
+
+    def comment_params
+      params.require(:comment).permit(:text)
+    end
   end
+end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -2,7 +2,7 @@ module Api
   class CommentsController < ApplicationController
     skip_before_action :authenticate_user!, only: %i[index create]
     skip_before_action :verify_authenticity_token
-    before_action :authenticate_user!, only: [:create]
+    # before_action :authenticate_user!, only: [:create]
     before_action :set_user_post
 
     def index
@@ -13,9 +13,10 @@ module Api
     end
 
     def create
-      @user = current_user
+      @user = User.find(params[:user_id])
       @post = @user.posts.find(params[:post_id])
       @comment = @post.comments.new(comment_params)
+      @comment.user = @user
 
       if @comment.save
         render json: @comment, status: :created

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -2,6 +2,7 @@ module Api
   class CommentsController < ApplicationController
     skip_before_action :authenticate_user!, only: %i[index create]
     skip_before_action :verify_authenticity_token
+    before_action :authenticate_user!, only: [:create]
     before_action :set_user_post
 
     def index
@@ -12,10 +13,9 @@ module Api
     end
 
     def create
-      @user = User.find(params[:user_id])
+      @user = current_user
       @post = @user.posts.find(params[:post_id])
       @comment = @post.comments.new(comment_params)
-      @comment.user = @user
 
       if @comment.save
         render json: @comment, status: :created

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,0 +1,16 @@
+module
+  class Api::PostsController < ApplicationController
+    skip_before_action :authenticate_user!
+    def index
+      user = User.find(params[:user_id])
+      posts = user.posts
+      render json: posts
+    end
+
+    def show
+      user = User.find(params[:user_id])
+      post = user.posts.find(params[:id])
+      render json: post
+    end
+  end
+end

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,5 +1,5 @@
-module
-  class Api::PostsController < ApplicationController
+module Api
+  class PostsController < ApplicationController
     skip_before_action :authenticate_user!
     def index
       user = User.find(params[:user_id])

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,0 +1,16 @@
+# app/controllers/api/users_controller.rb
+
+module Api
+  class UsersController < ApplicationController
+    skip_before_action :authenticate_user!
+    def index
+      @users = User.all
+      render json: @users
+    end
+
+    def show
+      @user = User.find(params[:id])
+      render json: @user
+    end
+  end
+end

--- a/app/helpers/api/comments_helper.rb
+++ b/app/helpers/api/comments_helper.rb
@@ -1,0 +1,2 @@
+module Api::CommentsHelper
+end

--- a/app/helpers/api/posts_helper.rb
+++ b/app/helpers/api/posts_helper.rb
@@ -1,0 +1,2 @@
+module Api::PostsHelper
+end

--- a/app/helpers/api/users_helper.rb
+++ b/app/helpers/api/users_helper.rb
@@ -1,0 +1,2 @@
+module Api::UsersHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :confirmable
+         :recoverable, :rememberable, :validatable, :confirmable,
+         :jwt_authenticatable, jwt_revocation_strategy: Devise::JWT::RevocationStrategies::Null
   has_many :posts, foreign_key: :author_id, dependent: :destroy
 
   has_many :comments, dependent: :destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,12 @@ Rails.application.routes.draw do
       resources :likes, only: [:create, :destroy]
     end
   end
+
+  namespace :api, defaults: { format: 'json' } do
+    resources :users, only: [:index, :show] do
+      resources :posts, only: [:index, :show] do
+        resources :comments, only: [:index, :create]
+      end
+    end
+  end
 end

--- a/spec/helpers/api/comments_helper_spec.rb
+++ b/spec/helpers/api/comments_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::CommentsHelper. For example:
+#
+# describe Api::CommentsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::CommentsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/api/posts_helper_spec.rb
+++ b/spec/helpers/api/posts_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::PostsHelper. For example:
+#
+# describe Api::PostsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::PostsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/api/users_helper_spec.rb
+++ b/spec/helpers/api/users_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::UsersHelper. For example:
+#
+# describe Api::UsersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::UsersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/api/comments_spec.rb
+++ b/spec/requests/api/comments_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Comments", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/comments_spec.rb
+++ b/spec/requests/api/comments_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Api::Comments", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Api::Comments', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::Posts', type: :request do
+  describe 'GET /index' do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Users", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Api::Users", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Api::Users', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end


### PR DESCRIPTION
In this PR the following were implemented:

We created an API endpoint to list all posts for a user.
<img width="1273" alt="image" src="https://github.com/George7h/blog/assets/101390796/2fd564fc-a632-4fb5-93fb-becf19b3b449">


We created an API endpoint to list all comments for a user's post.
<img width="1275" alt="image" src="https://github.com/George7h/blog/assets/101390796/d1fe8e58-8c38-42fb-8690-4042ae79ab67">


We created an API endpoint to add a comment to a post:
The owner of the comment is the user making the comment. Thus we can't send the request without hardcoding the ID of the user or implementing a JWT. but the routes and controllers are working and require the current user ID.
<img width="1274" alt="image" src="https://github.com/George7h/blog/assets/101390796/497cb004-6468-4689-947b-24d11f75bf30">
<img width="1082" alt="image" src="https://github.com/George7h/blog/assets/101390796/b61d27e7-a51e-453a-9e02-f3105fd589f4">

